### PR TITLE
Add info about requirements for set bonuses

### DIFF
--- a/d2s.go
+++ b/d2s.go
@@ -588,8 +588,9 @@ func parseItemList(bfr io.ByteReader, itemCount int) ([]item, error) {
 
 			// If the item is part of a set, these bit will tell us how many lists
 			// of magical properties follow the one regular magical property list.
+			var setListValue uint64 = 0
 			if parsed.Quality == partOfSet {
-				setListValue := reverseBits(ibr.ReadBits64(5, true), 5)
+				setListValue = reverseBits(ibr.ReadBits64(5, true), 5)
 				readBits += 5
 
 				listCount, ok := setListMap[setListValue]
@@ -622,6 +623,16 @@ func parseItemList(bfr io.ByteReader, itemCount int) ([]item, error) {
 					}
 
 					parsed.SetAttributes = append(parsed.SetAttributes, setAttrList)
+				}
+				// The bits set in setListValue correspond to the number
+				// of items that need to be worn for each list of magical properties
+				// to be active
+				for i := 0; i < 5; i++ {
+					if (setListValue & (1 << uint(i)) == 0) {
+						continue
+					}
+					// bit position 0 means it requires >= 2 items worn, etc
+					parsed.SetAttributesReq = append(parsed.SetAttributesReq, uint(i+2))
 				}
 			}
 

--- a/d2s.go
+++ b/d2s.go
@@ -624,15 +624,20 @@ func parseItemList(bfr io.ByteReader, itemCount int) ([]item, error) {
 
 					parsed.SetAttributes = append(parsed.SetAttributes, setAttrList)
 				}
-				// The bits set in setListValue correspond to the number
-				// of items that need to be worn for each list of magical properties
-				// to be active
-				for i := 0; i < 5; i++ {
-					if (setListValue & (1 << uint(i)) == 0) {
-						continue
+				reqSetIDs, ok := setReqIDsMap[parsed.SetID]
+				if ok {
+					parsed.SetAttributesIDsReq = reqSetIDs
+				} else {
+					// The bits set in setListValue correspond to the number
+					// of items that need to be worn for each list of magical properties
+					// to be active
+					for i := 0; i < 5; i++ {
+						if (setListValue & (1 << uint(i)) == 0) {
+							continue
+						}
+						// bit position 0 means it requires >= 2 items worn, etc
+						parsed.SetAttributesNumReq = append(parsed.SetAttributesNumReq, uint(i+2))
 					}
-					// bit position 0 means it requires >= 2 items worn, etc
-					parsed.SetAttributesReq = append(parsed.SetAttributesReq, uint(i+2))
 				}
 			}
 

--- a/item.go
+++ b/item.go
@@ -45,6 +45,7 @@ type item struct {
 	SetName            string             `json:"set_name,omitempty"`
 	SetListCount       uint64             `json:"set_list_count"`
 	SetAttributes      [][]magicAttribute `json:"set_attributes"`
+	SetAttributesReq   []uint             `json:"set_attributes_req,omitempty"`
 	RareName           string             `json:"rare_name,omitempty"`
 	RareName2          string             `json:"rare_name2,omitempty"`
 	MagicalNameIDs     []uint64           `json:"magical_name_ids,omitempty"`

--- a/item.go
+++ b/item.go
@@ -45,7 +45,8 @@ type item struct {
 	SetName            string             `json:"set_name,omitempty"`
 	SetListCount       uint64             `json:"set_list_count"`
 	SetAttributes      [][]magicAttribute `json:"set_attributes"`
-	SetAttributesReq   []uint             `json:"set_attributes_req,omitempty"`
+	SetAttributesNumReq []uint            `json:"set_attributes_num_req,omitempty"`
+	SetAttributesIDsReq []uint64          `json:"set_attributes_ids_req,omitempty"`
 	RareName           string             `json:"rare_name,omitempty"`
 	RareName2          string             `json:"rare_name2,omitempty"`
 	MagicalNameIDs     []uint64           `json:"magical_name_ids,omitempty"`
@@ -472,6 +473,15 @@ var setListMap = map[uint64]uint64{
 	12: 2,
 	15: 4,
 	31: 5,
+}
+
+// Certain set items (only Civerb's Ward in unmodded D2) have bonuses
+// that require certain other set items in order to be activated
+// (instead of the normal requirements of just 'wearing > x of any
+// items in the set'); determined by add_func=1 in SetItems.txt
+var setReqIDsMap = map[uint64][]uint64{
+	// Civerb's Ward: [Civerb's Icon, Civerb's Cudgel]
+	0: []uint64{1, 2},
 }
 
 // All item types that contain the quantity bits will exist in here,


### PR DESCRIPTION
~~EDIT: Note that this PR does not account for the case where bonuses are dependent on specific items being worn (`add_func` 1 in SetItems.txt). See [this comment](https://github.com/nokka/d2s/issues/5#issuecomment-473919562) and the ones after it.~~ Updated with Civerb's Ward's special case handled.

---

`set_attributes_num_req` and `set_attributes_ids_req` are companion arrays to `set_attributes` that stores the number of items that need to be worn or the set ids of the specific set items that need to be worn in order for the corresponding property list to be active. Only one or the other (`set_attributes_num_req` or `set_attributes_ids_req`) will exist in the json for any given set item. Only Civerb's Ward uses `set_attributs_ids_req`, every other set item will use `set_attributes_num_req`.

Example json output:
```javascript
"set_attributes": [
  [{"id":43,"name":"Cold Resist +{0}%","values":[40]}]
],
"set_attributes_num_req": [3]
```

which means that set_attributes[0] requires >= 3 items (since set_attributes_req[0] is 3) of the set to be worn to receive those bonuses

Example json output for Civerb's Ward:
```javascript
"set_attributes": [
  [ {"id":9,"name":"+{0} to Mana","values":[21]} ],
  [ {"id":45,"name":"Poison Resist +{0}%","values":[25]} ]
],
"set_attributes_ids_req": [1,2]
```

which means that set_attributes[0] requires set ID 1 to be worn (Civerb's amulet) in order to receive those bonuses, and that set_attributes[1] requires set ID 2 to be worn (Civerb's scepter) in order to receive those bonuses.

Addresses #5

---

Another example of an IK set item:
```javascript
  "set_attributes": [
    [
      {
        "id": 48,
        "name": "Adds {0}-{1} Fire Damage",
        "values": [211, 397]
      }
    ],
    [
      {
        "id": 50,
        "name": "Adds {0}-{1} Lightning Damage",
        "values": [7, 477]
      }
    ],
    [
      {
        "id": 54,
        "name": "Adds {0}-{1} Cold Damage",
        "values": [127, 364, 150]
      }
    ],
    [
      {
        "id": 57,
        "name": "Adds {0}-{1} Poison Damage over {2} Seconds",
        "values": [349, 349,150]
      }
    ],
    [
      {
        "id": 52,
        "name": "Adds {0}-{1} Magic Damage",
        "values": [250, 361]
      }
    ]
  ],
  "set_attributes_num_req": [2, 3, 4, 5, 6]
```